### PR TITLE
Ensure ./tmp dir exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,15 +38,18 @@ module.exports = {
     }
   },
   preBuild: function(result) {
-    if(!fs.existsSync(var lockfile = this.lockfilePath())) { fs.openSync(lockfile, 'w'); }
-    if(fs.existsSync(var errorFile = this.errorFilePath())) { fs.unlinkSync(errorFile); }
+    var lockFile = this.lockFilePath();
+    var errorFile = this.errorFilePath();
+    if(!fs.existsSync(lockFile)) { fs.openSync(lockFile, 'w'); }
+    if(fs.existsSync(errorFile)) { fs.unlinkSync(errorFile); }
   },
   postBuild: function(result){
-    if(fs.existsSync(var lockfile = this.lockfilePath())) {
-      fs.unlinkSync(lockfile);
+    var lockFile = this.lockFilePath();
+    if(fs.existsSync(lockFile)) {
+      fs.unlinkSync(lockFile);
     }
   },
-  lockfilePath: function() {
+  lockFilePath: function() {
     return path.join(process.cwd(), 'tmp', 'build.lock');
   },
   errorFilePath: function() {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
 
   init: function() {
     this.warnMissingDependencyChecker();
+    this.ensureTmp();
   },
 
   buildError: function(error) {
@@ -49,10 +50,20 @@ module.exports = {
       fs.unlinkSync(lockFile);
     }
   },
+
+  ensureTmp: function() {
+    var dir = this.tmpDir();
+    if (!fs.existsSync(dir)){
+      fs.mkdirSync(dir);
+    }
+  },
+  tmpDir: function() {
+    path.join(process.cwd(), 'tmp');
+  },
   lockFilePath: function() {
-    return path.join(process.cwd(), 'tmp', 'build.lock');
+    return path.join(this.tmpDir(), 'build.lock');
   },
   errorFilePath: function() {
-    return path.join(process.cwd(), 'tmp', 'error.txt');
+    return path.join(this.tmpDir(), 'error.txt');
   }
 };


### PR DESCRIPTION
Building of ember app fails if `./tmp` folder within ember-cli root does not exist as `build.lock` file cannot be created. 

Normally `./tmp` folder is created in ember-cli build process; if ember-cli-rails-addon is added prior to first successful build, `./tmp` folder does not yet exist.

This PR ensures that tmp folder exists. It also fixes some syntax errors related to scoping of variables introduced in previous commit.

