### PR TITLE
Handle app.options.fingerprint not being set

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
     app.options.storeConfigInMeta = false;
 
     if (process.env.DISABLE_FINGERPRINTING === 'true') {
+      app.options.fingerprint = app.options.fingerprint || {};
       app.options.fingerprint.enabled = false;
     }
 


### PR DESCRIPTION
I ran into `Cannot set property 'enabled' of undefined` after upgrading to Ember CLI 1.13.5. It appears `app.options.fingerprint` now isn't being set by Ember internally, hence the error. Apps can also work around the issue by adding `fingerprint: {}` when creating their `EmberApp` in `ember-cli-build.js`, but it would be nice not to have to do this.