### PR TITLE
Copy Built dist/index.html to dist/assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+master
+------
+
+* Disables [Subresource Integrity][SRI], since the asset pipeline URLs no longer
+  match the URLs the SRI hashes were generated against.
+* Copies `dist/index.html` to `dist/assets/index.html` after a build
+
+[SRI]: https://github.com/jonathanKingston/ember-cli-sri#what-is-it

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ responsible for the following
   until EmberCLI has had a chance to fully build
 - Write build errors to a file so that `ember-cli-rails` can display them
   properly
+- Exposes `dist/index.html` to Rails' asset pipeline in order to survive the
+  cleanup after `rake assets:clean`
+- Disabled [Subresource Integrity][SRI], since the asset pipeline URLs no longer
+  match the URLs the SRI hashes were generated against.
+
+[SRI]: https://github.com/jonathanKingston/ember-cli-sri#what-is-it

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var fsExtra = require('fs-extra');
 var path = require('path');
 
 module.exports = {
@@ -22,6 +23,8 @@ module.exports = {
 
   included: function(app) {
     app.options.storeConfigInMeta = false;
+    app.options.SRI = app.options.SRI || {};
+    app.options.SRI.enabled = false;
 
     if (process.env.DISABLE_FINGERPRINTING === 'true') {
       app.options.fingerprint = app.options.fingerprint || {};
@@ -46,7 +49,13 @@ module.exports = {
     if(fs.existsSync(errorFile)) { fs.unlinkSync(errorFile); }
   },
   postBuild: function(result){
+    fsExtra.copySync(
+      result.directory + '/index.html',
+      result.directory + '/assets/index.html'
+    );
+
     var lockFile = this.lockFilePath();
+
     if(fs.existsSync(lockFile)) {
       fs.unlinkSync(lockFile);
     }

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "ember-addon"
   ],
   "author": "Jonathan Jackson",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "fs-extra": "^0.26.0"
+  }
 }


### PR DESCRIPTION
During `ember-cli-rails`'s build process, `dist/assets` is symlinked
into the appropriate directory for exposure to the Asset Pipeline.

Although it won't ever be requested, moving the `index.html` into the
asset directory will ensure that it survives Heroku's cleanup step.