### PR TITLE
Disable EmberCLI JS minification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 master
 ------
 
+* Disable EmberCLI minification (closes [thoughtbot/ember-cli-rails#123][123] and
+  [thoughtbot/ember-cli-rails#124][124])
+
+[123]: https://github.com/thoughtbot/ember-cli-rails/pull/123
+[124]: https://github.com/thoughtbot/ember-cli-rails/pull/124
+
 0.0.13
 ------
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = {
   },
 
   included: function(app) {
+    app.options.minifyJS = false;
     app.options.storeConfigInMeta = false;
     app.options.SRI = app.options.SRI || {};
     app.options.SRI.enabled = false;


### PR DESCRIPTION
When precompiling assets in production, we ensure that we are not
minifying the JavaScript assets twice.

Duplicating minification can slow down assets precompilation
considerably.

Closes [thoughtbot/ember-cli-rails#124][124] and
[thoughtbot/ember-cli-rails#123][123].

[123]: thoughtbot/ember-cli-rails#123
[124]: thoughtbot/ember-cli-rails#124