### PR TITLE
Prepare URLs for Sprockets Asset Pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+
+cache:
+  directories:
+    - node_modules
+
+language: node_js
+node_js:
+- '4.1'
+- '0.12'
+- '0.10'
+
+notifications:
+  email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 master
 ------
 
+* Prepend Sprockets path to EmberCLI assets.
+  Default fingerprinting to no generate `MD5` hash when building in
+  `development`.  [#17].
+
+[#17]: https://github.com/rondale-sc/ember-cli-rails-addon/pull/17
+
 0.0.13
 ------
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
 # EmberCLI Rails Addon
 
-This is an integration piece between
-[ember-cli-rails](https://github.com/rwz/ember-cli-rails/pull/25/files) (the
-rubygem) and the EmberCLI applications they reference.  This addon is
-responsible for the following
+This is an integration piece between the [ember-cli-rails] gem and the
+EmberCLI applications the Rails applications serve.
 
-- Setting expected build variables without the user having to manipulate their
-  EmberCLI app's `Brocfile`
-- Creating lockfiles that `ember-cli-rails` tracks to ensure that requests halt
+This addon is responsible for:
+
+- preprending Sprockets-ready paths to asset URLs. Unless already specified,
+  the addon will default to prepending `${HOST}/assets/${NAME}/`, where `NAME`
+  is determined by the `name` specified in the application's `package.json`,
+  and `HOST` is determined in the following order:
+
+  1. `process.env.ASSET_HOST` (usually set for [Rails' Asset Pipeline][asset-host])
+  1. `process.env.CDN_HOST` (usually set for Rails' Asset Pipeline)
+  1. `app.options.origin` (see [ember-cli-sri][origin])
+
+[asset-host]: https://robots.thoughtbot.com/dns-cdn-origin#making-it-work-with-rails
+[origin]: https://github.com/jonathanKingston/ember-cli-sri#configure
+
+- setting expected build variables without the user having to manipulate their
+  EmberCLI app's `ember-cli-build.js`
+- creating lockfiles that `ember-cli-rails` tracks to ensure that requests halt
   until EmberCLI has had a chance to fully build
-- Write build errors to a file so that `ember-cli-rails` can display them
-  properly
-- Exposes `dist/index.html` to Rails' asset pipeline in order to survive the
-  cleanup after `rake assets:clean`
-- Disabled [Subresource Integrity][SRI], since the asset pipeline URLs no longer
-  match the URLs the SRI hashes were generated against.
+- writing build errors to a file so that `ember-cli-rails` can display them
+  as Rails errors.
 
+[ember-cli-rails]: https://github.com/thoughtbot/ember-cli-rails
 [SRI]: https://github.com/jonathanKingston/ember-cli-sri#what-is-it

--- a/index.js
+++ b/index.js
@@ -2,6 +2,14 @@ var fs = require('fs');
 var fsExtra = require('fs-extra');
 var path = require('path');
 
+function softSet(object, key, value) {
+  object = object || {};
+
+  if (typeof object[key] === 'undefined') {
+    object[key] = value;
+  }
+}
+
 module.exports = {
   name: 'ember-cli-rails-addon',
   warnMissingDependencyChecker: function() {
@@ -22,13 +30,27 @@ module.exports = {
   },
 
   included: function(app) {
-    app.options.storeConfigInMeta = false;
-    app.options.SRI = app.options.SRI || {};
-    app.options.SRI.enabled = false;
+    softSet(app.options, 'storeConfigInMeta', false);
+    softSet(app.options, 'fingerprint', {});
 
-    if (process.env.DISABLE_FINGERPRINTING === 'true') {
-      app.options.fingerprint = app.options.fingerprint || {};
-      app.options.fingerprint.enabled = false;
+    if (typeof process.env.RAILS_ENV !== 'undefined') {
+      var origin = process.env.ASSET_HOST ||
+                   process.env.CDN_HOST ||
+                    app.options.origin ||
+                   '';
+
+      softSet(app.options.fingerprint, 'enabled', true);
+      softSet(app.options.fingerprint, 'prepend', [
+          origin,
+          '/assets/',
+          app.name,
+          '/',
+        ].join('')
+      );
+
+      if (app.env !== 'production') {
+        softSet(app.options.fingerprint, 'customHash', null);
+      }
     }
 
     if (process.env.EXCLUDE_EMBER_ASSETS) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/rondale-sc/ember-cli-rails-addon",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "qunit -c index.js -t tests/*-test.js"
   },
   "keywords": [
     "ember-addon"
@@ -14,5 +14,8 @@
   "license": "ISC",
   "dependencies": {
     "fs-extra": "^0.26.0"
+  },
+  "devDependencies": {
+    "qunit": "^0.7.7"
   }
 }

--- a/tests/addon-test.js
+++ b/tests/addon-test.js
@@ -1,0 +1,56 @@
+var Addon = require('../index');
+
+QUnit.module('Addon index');
+
+test('#included without RAILS_ENV', function() {
+  delete process.env.RAILS_ENV;
+  var app = {
+    name: 'test-app',
+    options: {},
+  };
+
+  Addon.included(app);
+
+  equal(app.options.storeConfigInMeta, false, 'disables storeConfigInMeta');
+});
+
+test('#included with RAILS_ENV in development', function() {
+  process.env.RAILS_ENV = 'development';
+  var app = {
+    name: 'test-app',
+    env: 'development',
+    options: {},
+  };
+
+  Addon.included(app);
+  var fingerprint = app.options.fingerprint;
+
+  ok(fingerprint.enabled, 'turns on fingerprinting');
+  equal(fingerprint.prepend, '/assets/test-app/', 'prepends Sprockets path');
+  equal(fingerprint.customHash, null, 'disables asset hashing');
+
+  var appWithPrepend = {
+    options: {
+      fingerprint: {
+        prepend: 'foo',
+      }
+    }
+  };
+
+  Addon.included(appWithPrepend);
+
+  equal(appWithPrepend.options.fingerprint.prepend, 'foo', 'can be overridden');
+});
+
+test('#included with RAILS_ENV in production', function() {
+  process.env.RAILS_ENV = 'production';
+  var app = {
+    env: 'production',
+    options: {},
+  };
+
+  Addon.included(app);
+  var fingerprint = app.options.fingerprint;
+
+  equal(typeof fingerprint.customHash, 'undefined', 'uses default customHash');
+});


### PR DESCRIPTION
Initial steps toward closing [thoughtbot/ember-cli-rails#30][#30].


* Generate Rails `manifest.json` when building from Rails.
* Prepend Sprockets path to EmberCLI assets.
* Default fingerprinting to no generate `MD5` hash when building in
  `development`.

[#30]: https://github.com/thoughtbot/ember-cli-rails/issues/30