### PR TITLE
Set `X-CSRF-Token` on HTTP requests

### DIFF
--- a/app/initializers/ember-cli-rails-addon-csrf.js
+++ b/app/initializers/ember-cli-rails-addon-csrf.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+const { $ } = Ember;
+
+export default {
+  name: 'ember-cli-rails-addon-csrf',
+
+  initialize() {
+    $.ajaxPrefilter((options, originalOptions, xhr) => {
+      const token = $('meta[name="csrf-token"]').attr('content');
+      xhr.setRequestHeader('X-CSRF-Token', token);
+    });
+  },
+};


### PR DESCRIPTION
https://github.com/emberjs/ember-rails#csrf-token
https://github.com/thoughtbot/ember-cli-rails#csrf-tokens

When `ember-cli-rails` embeds the CSRF meta tags, this initializer
configures the host app to recognize them and set them as outgoing HTTP
headers to play nice with the Rails app's CSRF protection.