### PR TITLE
Don't Fingerprint in `--environment test`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* Don't fingerprint assets when running `ember test` from Rails.
 * Introduce file in `app/initializers` to setup Rails CSRF integration [#19]
 * Prepend Sprockets path to EmberCLI assets.
   Default fingerprinting to no generate `MD5` hash when building in

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = {
     app.options.storeConfigInMeta = false;
     softSet(app.options, 'fingerprint', {});
 
-    if (typeof process.env.RAILS_ENV !== 'undefined') {
+    if (app.env !== 'test' && typeof process.env.RAILS_ENV !== 'undefined') {
       var origin = process.env.ASSET_HOST ||
                    process.env.CDN_HOST ||
                    app.options.origin ||


### PR DESCRIPTION
When running `ember test` from Rails, don't fingerprint assets.