### PR TITLE
Introduce `prefix` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 master
 ------
 
+* Generate a Rails-compatible asset manifest file. [#23]
 * Introduce `prefix` configuration which corresponds to Rails'
   [`config.assets.prefix`][prefix]. To match Rails, it defaults to `assets`.
+
+[#23]: https://github.com/rondale-sc/ember-cli-rails-addon/pull/23
 
 0.5.1
 -----

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = {
       }
 
       softSet(app.options.fingerprint, 'enabled', true);
+      softSet(app.options.fingerprint, 'generateRailsManifest', true);
       softSet(app.options.fingerprint, 'prepend', prepend);
 
       if (app.env !== 'production') {


### PR DESCRIPTION
Closes [thoughtbot/ember-cli-rails#298][#298].

For Rails to integrate Ember into the asset pipeline, EmberCLI must
generate a Sprockets-compatible manifest file, which Rails will merge
into its own Asset manifest.

[#298]: https://github.com/thoughtbot/ember-cli-rails/issues/298