### PR TITLE
Simplify option configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 master
 ------
 
+* Simplify inclusion logic thanks to removal of sprockets. [#25]
+
+[#25]: https://github.com/rondale-sc/ember-cli-rails-addon/pull/25
+
 0.5.2
 -----
 

--- a/index.js
+++ b/index.js
@@ -32,27 +32,8 @@ module.exports = {
 
   included: function(app) {
     app.options.storeConfigInMeta = false;
-    softSet(app.options, 'fingerprint', {});
-    softSet(app.options, 'ember-cli-rails', {});
-    var addonOptions = app.options['ember-cli-rails'];
-
-    if (app.env !== 'test' && typeof process.env.RAILS_ENV !== 'undefined') {
-      var prefix = addonOptions.prefix || 'assets';
-      var assetHostWithProtocol = addonOptions.prepend || '';
-      var prepend = urlJoin(assetHostWithProtocol, prefix, app.name);
-
-      if (prepend.slice(-1) !== '/') {
-        prepend += '/';
-      }
-
-      softSet(app.options.fingerprint, 'enabled', true);
-      softSet(app.options.fingerprint, 'generateRailsManifest', true);
-      softSet(app.options.fingerprint, 'prepend', prepend);
-
-      if (app.env !== 'production') {
-        softSet(app.options.fingerprint, 'customHash', null);
-      }
-    }
+    app.options.fingerprint = app.options.fingerprint || {};
+    app.options.fingerprint.generateAssetMap = true;
 
     if (process.env.EXCLUDE_EMBER_ASSETS) {
       var excludeEmberAssets = process.env.EXCLUDE_EMBER_ASSETS;

--- a/tests/addon-test.js
+++ b/tests/addon-test.js
@@ -2,73 +2,29 @@ var Addon = require('../index');
 
 QUnit.module('Addon index');
 
-test('#included without RAILS_ENV', function() {
-  delete process.env.RAILS_ENV;
+test('included with default options', function() {
   var app = {
-    name: 'test-app',
     options: {},
   };
 
   Addon.included(app);
 
-  equal(app.options.storeConfigInMeta, false, 'disables storeConfigInMeta');
+  ok(!app.options.storeConfigInMeta, 'disables storing config in `<meta>`');
+  ok(app.options.fingerprint.generateAssetMap, 'generates `assetMap.json`');
 });
 
-test('#included with RAILS_ENV in development', function() {
-  process.env.RAILS_ENV = 'development';
+test('overrides options', function() {
   var app = {
-    name: 'test-app',
-    env: 'development',
-    options: {},
-  };
-
-  Addon.included(app);
-  var fingerprint = app.options.fingerprint;
-
-  ok(fingerprint.enabled, 'turns on fingerprinting');
-  equal(fingerprint.prepend, '/assets/test-app/', 'prepends Sprockets path');
-  equal(fingerprint.customHash, null, 'disables asset hashing');
-
-  var appWithPrepend = {
     options: {
+      storeConfigInMeta: true,
       fingerprint: {
-        prepend: 'example.com/',
+        generateAssetMap: false,
       }
-    }
-  };
-
-  Addon.included(appWithPrepend);
-
-  equal(appWithPrepend.options.fingerprint.prepend, 'example.com/', 'can be overridden');
-
-  var appWithAddonConfig = {
-    name: 'test-app',
-    options: {
-      'ember-cli-rails': {
-        prepend: 'https://example.com',
-        prefix: '/staging/assets',
-      }
-    }
-  };
-
-  Addon.included(appWithAddonConfig);
-
-  equal(
-    appWithAddonConfig.options.fingerprint.prepend,
-    'https://example.com/staging/assets/test-app/',
-    'asset host can be configured'
-  );
-});
-
-test('#included with RAILS_ENV in production', function() {
-  process.env.RAILS_ENV = 'production';
-  var app = {
-    env: 'production',
-    options: {},
+    },
   };
 
   Addon.included(app);
-  var fingerprint = app.options.fingerprint;
 
-  equal(typeof fingerprint.customHash, 'undefined', 'uses default customHash');
+  ok(!app.options.storeConfigInMeta, 'disables storing config in `<meta>`');
+  ok(app.options.fingerprint.generateAssetMap, 'generates `assetMap.json`');
 });


### PR DESCRIPTION
No longer overrides:

* `fingerprint.enabled`
* `fingerprint.generateRailsManifest`
* `fingerprint.prepend`
* `fingerprint.customHash`

Overrides:

* `storeConfigInMeta` - for using `include_ember_*_tags` helpers
* `generateAssetMap` - for properly serving assets