### PR TITLE
Replace `postBuild` with `outputReady` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* Wait until [outputReady] hook to remove lockfile.
 * Remove dependency on `url-join` and `fs-extra` packages.
 * Simplify inclusion logic thanks to removal of sprockets. [#25]
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = {
     if(fs.existsSync(errorFile)) { fs.unlinkSync(errorFile); }
   },
 
-  postBuild: function(result){
+  outputReady: function(result){
     var lockFile = this.lockFilePath();
 
     if(fs.existsSync(lockFile)) {


### PR DESCRIPTION
Closes [#331].
Closes [#349].

According to the [addon hook documentation][hooks]:

`#postBuild`

> Gives access to the result of the tree, and the location of the output.

`#outputReady`

> Hook called after the build has been processed and the files have been
> copied to the output directory

Since we're now blocking until the `index.html` it built and in the
output directory, `outputReady` is the behavior we depend on.

[hooks]: https://github.com/ember-cli/ember-cli/blob/082d559757b3d6d186fc1c3cd1b7c2bb1ad10b3f/ADDON_HOOKS.md#outputready
[#331]: https://github.com/thoughtbot/ember-cli-rails/issues/331
[#349]: https://github.com/thoughtbot/ember-cli-rails/pull/349