### PR TITLE
Remove Ember CLI init super deprecation (DEPRECATION: Overriding init without calling this._super is deprecated.)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   name: 'ember-cli-rails-addon',
 
   init: function() {
-    this._super.apply(this, arguments);
+    this._super.init && this._super.init.apply(this, arguments);
     this.ensureTmp();
   },
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   name: 'ember-cli-rails-addon',
 
   init: function() {
-    this._super(...arguments);
+    this._super.apply(this, arguments);
     this.ensureTmp();
   },
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
   name: 'ember-cli-rails-addon',
 
   init: function() {
+    this._super(...arguments);
     this.ensureTmp();
   },
 


### PR DESCRIPTION
Getting an deprecation on every Ember command:

````
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-rails-addon`
    at Function.Addon.lookup (/Users/jbremer/productdev/rogue/frontend/node_modules/ember-cli/lib/models/addon.js:896:27)
````