### PR TITLE
Don't add X-CSRF-Token if request is cross domain

### DIFF
--- a/app/initializers/ember-cli-rails-addon-csrf.js
+++ b/app/initializers/ember-cli-rails-addon-csrf.js
@@ -7,8 +7,10 @@ export default {
 
   initialize() {
     $.ajaxPrefilter((options, originalOptions, xhr) => {
-      const token = $('meta[name="csrf-token"]').attr('content');
-      xhr.setRequestHeader('X-CSRF-Token', token);
+      if (!options.crossDomain) {
+        const token = $('meta[name="csrf-token"]').attr('content');
+        xhr.setRequestHeader('X-CSRF-Token', token);
+      }
     });
   },
 };


### PR DESCRIPTION
Since there is no way to remove an element from the `Access-Control-Request-Headers` after you set a the request header on the xhr object, we need to add in a check to not set the `X-CSRF-Token` when the performing a cross domain request.

With this change, you can set the `crossDomain: true` property (as below) of an ajax call and it not include the `X-CSRF-Token` which would otherwise fail during the preflight response in applications that do not support that token as indicated by the `Access-Control-Allow-Headers` of their response. 

```
$.ajax({
      ...
      crossDomain: true,
});
```