### PR TITLE
if jquery installed already, use that version, otherwise use Ember's

### DIFF
--- a/app/initializers/ember-cli-rails-addon-csrf.js
+++ b/app/initializers/ember-cli-rails-addon-csrf.js
@@ -1,11 +1,13 @@
 import Ember from 'ember';
 
-const { $ } = Ember;
-
 export default {
   name: 'ember-cli-rails-addon-csrf',
 
   initialize() {
+    if (typeof $ == undefined) {
+      const { $ } = Ember;
+    }
+
     $.ajaxPrefilter((options, originalOptions, xhr) => {
       const token = $('meta[name="csrf-token"]').attr('content');
       xhr.setRequestHeader('X-CSRF-Token', token);


### PR DESCRIPTION
This problem is occuring when you are using `ember-cli-rails` on a Rails project that has Jquery already. Also with [@ember/optinal-features](https://www.npmjs.com/package/@ember/optional-features) package, Jquery is an optional dependency for Ember projects, so it should not be a hard dependency.