### PR TITLE
Make jQuery support optional

### DIFF
--- a/app/initializers/ember-cli-rails-addon-csrf.js
+++ b/app/initializers/ember-cli-rails-addon-csrf.js
@@ -1,14 +1,14 @@
 import Ember from 'ember';
 
-const { $ } = Ember;
-
 export default {
   name: 'ember-cli-rails-addon-csrf',
 
   initialize() {
-    $.ajaxPrefilter((options, originalOptions, xhr) => {
-      const token = $('meta[name="csrf-token"]').attr('content');
-      xhr.setRequestHeader('X-CSRF-Token', token);
-    });
+    if(Ember.$ && Ember.$.ajaxPrefilter) {
+      Ember.$.ajaxPrefilter((options, originalOptions, xhr) => {
+        const token = Ember.$('meta[name="csrf-token"]').attr('content');
+        xhr.setRequestHeader('X-CSRF-Token', token);
+      });
+    }
   },
 };


### PR DESCRIPTION
This is needed for this plugin to work with Ember Octane. This is a pretty minimal change which doesn't make CSRF work properly in Octane but simply ensures this doesn't blow up if jQuery isn't loaded. A more comprehensive change might be providing some kind of mixin for the adapter or something? I don't know Ember very well yet, so I'm not too sure on the best way to proceed here.